### PR TITLE
Update of API

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,14 @@ import (
 
 func main() {
     client := quobyte_api.NewQuobyteClient("http://apiserver:7860", "user", "password")
-    volume_uuid, err := client.CreateVolume("MyVolume", "root", "root")
+    req := &quobyte_api.CreateVolumeRequest{
+        Name:              "MyVolume",
+        RootUserID:        "root",
+        RootGroupID:       "root",
+        ConfigurationName: "base",
+    }
+
+    volume_uuid, err := client.CreateVolume(req)
     if err != nil {
         log.Fatalf("Error:", err)
     }

--- a/quobyte.go
+++ b/quobyte.go
@@ -20,9 +20,9 @@ func NewQuobyteClient(url string, username string, password string) *QuobyteClie
 	}
 }
 
-// Create a new Quobyte volume. Its root directory will be owned by given user and group
+// CreateVolume creates a new Quobyte volume. Its root directory will be owned by given user and group
 func (client QuobyteClient) CreateVolume(request *CreateVolumeRequest) (string, error) {
-	var response createVolumeResponse
+	var response volumeUUID
 	if err := client.sendRequest("createVolume", request, &response); err != nil {
 		return "", err
 	}
@@ -31,11 +31,12 @@ func (client QuobyteClient) CreateVolume(request *CreateVolumeRequest) (string, 
 }
 
 // ResolveVolumeNameToUUID resolves a volume name to a UUID
-func (client QuobyteClient) ResolveVolumeNameToUUID(volumeName string) (string, error) {
+func (client *QuobyteClient) ResolveVolumeNameToUUID(volumeName, tenant string) (string, error) {
 	request := &resolveVolumeNameRequest{
-		VolumeName: volumeName,
+		VolumeName:   volumeName,
+		TenantDomain: tenant,
 	}
-	var response resolveVolumeNameResponse
+	var response volumeUUID
 	if err := client.sendRequest("resolveVolumeName", request, &response); err != nil {
 		return "", err
 	}
@@ -43,20 +44,36 @@ func (client QuobyteClient) ResolveVolumeNameToUUID(volumeName string) (string, 
 	return response.VolumeUUID, nil
 }
 
-// Delete a Quobyte volume. Its root directory will be owned by given user and group and have access 700.
-func (client QuobyteClient) DeleteVolume(volumeUUID string) error {
-	request := &deleteVolumeRequest{
-		VolumeUUID: volumeUUID,
-	}
-
-	return client.sendRequest("deleteVolume", request, nil)
+// DeleteVolume deletes a Quobyte volume
+func (client *QuobyteClient) DeleteVolume(UUID string) error {
+	return client.sendRequest(
+		"deleteVolume",
+		&volumeUUID{
+			VolumeUUID: UUID,
+		},
+		nil)
 }
 
-func (client QuobyteClient) DeleteVolumeByName(volumeName string) error {
-	uuid, err := client.ResolveVolumeNameToUUID(volumeName)
+// DeleteVolumeByName deletes a volume by a given name
+func (client *QuobyteClient) DeleteVolumeByName(volumeName, tenant string) error {
+	uuid, err := client.ResolveVolumeNameToUUID(volumeName, tenant)
 	if err != nil {
 		return err
 	}
 
 	return client.DeleteVolume(uuid)
+}
+
+// GetClientList returns a list of all active clients
+func (client *QuobyteClient) GetClientList(tenant string) (GetClientListResponse, error) {
+	request := &getClientListRequest{
+		TenantDomain: tenant,
+	}
+
+	var response GetClientListResponse
+	if err := client.sendRequest("getClientListRequest", request, &response); err != nil {
+		return response, err
+	}
+
+	return response, nil
 }

--- a/quobyte.go
+++ b/quobyte.go
@@ -1,12 +1,7 @@
 // Package quobyte represents a golang API for the Quobyte Storage System
 package quobyte
 
-import (
-	"bytes"
-	"net/http"
-
-	"github.com/gorilla/rpc/v2/json2"
-)
+import "net/http"
 
 type QuobyteClient struct {
 	client   *http.Client
@@ -64,28 +59,4 @@ func (client QuobyteClient) DeleteVolumeByName(volumeName string) error {
 	}
 
 	return client.DeleteVolume(uuid)
-}
-
-func (client QuobyteClient) sendRequest(method string, request interface{}, response interface{}) error {
-	message, err := json2.EncodeClientRequest(method, request)
-	if err != nil {
-		return err
-	}
-	req, err := http.NewRequest("POST", client.url, bytes.NewBuffer(message))
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.SetBasicAuth(client.username, client.password)
-	resp, err := client.client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	err = json2.DecodeClientResponse(resp.Body, &response)
-	if err != nil {
-		return err
-	}
-	return nil
 }

--- a/quobyte.go
+++ b/quobyte.go
@@ -15,23 +15,18 @@ type QuobyteClient struct {
 	password string
 }
 
-// Create a new Quobyte API client
+// NewQuobyteClient creates a new Quobyte API client
 func NewQuobyteClient(url string, username string, password string) *QuobyteClient {
-	result := new(QuobyteClient)
-	result.client = new(http.Client)
-	result.url = url
-	result.username = username
-	result.password = password
-	return result
+	return &QuobyteClient{
+		client:   &http.Client{},
+		url:      url,
+		username: username,
+		password: password,
+	}
 }
 
 // Create a new Quobyte volume. Its root directory will be owned by given user and group
-func (client QuobyteClient) CreateVolume(name string, rootUserName string, rootGroupName string) (string, error) {
-	request := &createVolumeRequest{
-		Name:        name,
-		RootUserID:  rootUserName,
-		RootGroupID: rootGroupName,
-	}
+func (client QuobyteClient) CreateVolume(request *CreateVolumeRequest) (string, error) {
 	var response createVolumeResponse
 	if err := client.sendRequest("createVolume", request, &response); err != nil {
 		return "", err
@@ -58,8 +53,8 @@ func (client QuobyteClient) DeleteVolume(volumeUUID string) error {
 	request := &deleteVolumeRequest{
 		VolumeUUID: volumeUUID,
 	}
-	var response deleteVolumeResponse
-	return client.sendRequest("deleteVolume", request, &response)
+
+	return client.sendRequest("deleteVolume", request, nil)
 }
 
 func (client QuobyteClient) DeleteVolumeByName(volumeName string) error {

--- a/rpc_client.go
+++ b/rpc_client.go
@@ -1,0 +1,103 @@
+package quobyte
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"math/rand"
+	"net/http"
+)
+
+type request struct {
+	ID      int64       `json:"id"`
+	Version string      `json:"jsonrpc"`
+	Method  string      `json:"method"`
+	Params  interface{} `json:"params"`
+}
+
+type response struct {
+	ID      int64            `json:"id"`
+	Version string           `json:"jsonrpc"`
+	Result  *json.RawMessage `json:"result"`
+	Error   *json.RawMessage `json:"error"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+func (err *rpcError) decodeErrorCode() string {
+	switch err.Code {
+	case -32600:
+		return "ERROR_CODE_INVALID_REQUEST"
+	case -32603:
+		return "ERROR_CODE_JSON_ENCODING_FAILED"
+	case -32601:
+		return "ERROR_CODE_METHOD_NOT_FOUND"
+	case -32700:
+		return "ERROR_CODE_PARSE_ERROR"
+	}
+
+	return ""
+}
+
+func encodeRequest(method string, params interface{}) ([]byte, error) {
+	return json.Marshal(&request{
+		ID:      int64(rand.Int63()),
+		Version: "2.0",
+		Method:  method,
+		Params:  params,
+	})
+}
+
+func decodeResponse(ioReader io.Reader, reply interface{}) error {
+	var resp response
+	if err := json.NewDecoder(ioReader).Decode(&resp); err != nil {
+		return err
+	}
+
+	if resp.Error != nil {
+		var rpcErr rpcError
+		if err := json.Unmarshal(*resp.Error, &rpcErr); err != nil {
+			if rpcErr.Message != "" {
+				return errors.New(rpcErr.Message)
+			}
+			respError := rpcErr.decodeErrorCode()
+			if respError != "" {
+				return errors.New(respError)
+			}
+
+			return err
+		}
+
+		return errors.New(rpcErr.Message)
+	}
+
+	if resp.Result != nil {
+		return json.Unmarshal(*resp.Result, reply)
+	}
+
+	return errors.New("Empty result and no error occured")
+}
+
+func (client QuobyteClient) sendRequest(method string, request interface{}, response interface{}) error {
+	message, err := encodeRequest(method, request)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequest("POST", client.url, bytes.NewBuffer(message))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.SetBasicAuth(client.username, client.password)
+	resp, err := client.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	return decodeResponse(resp.Body, &response)
+}

--- a/rpc_client.go
+++ b/rpc_client.go
@@ -75,7 +75,7 @@ func decodeResponse(ioReader io.Reader, reply interface{}) error {
 		return errors.New(rpcErr.Message)
 	}
 
-	if resp.Result != nil {
+	if resp.Result != nil && reply != nil {
 		return json.Unmarshal(*resp.Result, reply)
 	}
 

--- a/rpc_client_test.go
+++ b/rpc_client_test.go
@@ -1,7 +1,9 @@
 package quobyte
 
 import (
+	"bytes"
 	"encoding/json"
+	"math/rand"
 	"reflect"
 	"testing"
 )
@@ -25,17 +27,10 @@ func TestSuccesfullEncodeRequest(t *testing.T) {
 		Params:  param,
 	}
 
-	res, err := encodeRequest("createVolume", req)
-	if err != nil {
-		t.Log(err)
-		t.FailNow()
-	}
+	res, _ := encodeRequest("createVolume", req)
 
 	var reqResult request
-	if err := json.Unmarshal(res, &reqResult); err != nil {
-		t.Log(err)
-		t.FailNow()
-	}
+	json.Unmarshal(res, &reqResult)
 
 	if expectedRPCRequest.Version != reqResult.Version {
 		t.Logf("Expected Version: %s got %s\n", expectedRPCRequest.Version, reqResult.Version)
@@ -53,10 +48,131 @@ func TestSuccesfullEncodeRequest(t *testing.T) {
 	}
 }
 
-//TODO
-func TestSuccesfullDecodeResponse(t *testing.T) {}
+func TestSuccesfullDecodeResponse(t *testing.T) {
+	var byt json.RawMessage
+	byt, _ = json.Marshal(map[string]interface{}{"volume_uuid": "1234"})
 
-//TODO
-func TestSuccesfullDecodeResponseWithError(t *testing.T) {}
+	expectedResult := &response{
+		ID:      int64(rand.Int63()),
+		Version: "2.0",
+		Result:  &byt,
+	}
 
-//TODO test -> decodeErrorCode
+	res, _ := json.Marshal(expectedResult)
+
+	var resp volumeUUID
+	err := decodeResponse(bytes.NewReader(res), &resp)
+	if err != nil {
+		t.Log(err)
+		t.Fail()
+	}
+
+	if "1234" != resp.VolumeUUID {
+		t.Logf("Expected Volume UUID: %v got %v\n", "1234", resp.VolumeUUID)
+		t.Fail()
+	}
+}
+
+func TestSuccesfullDecodeResponseWithErrorMessage(t *testing.T) {
+	errorMessage := "ERROR_CODE_INVALID_REQUEST"
+	var byt json.RawMessage
+	byt, _ = json.Marshal(&rpcError{
+		Code:    -32600,
+		Message: "ERROR_CODE_INVALID_REQUEST",
+	})
+
+	expectedResult := &response{
+		ID:      int64(rand.Int63()),
+		Version: "2.0",
+		Error:   &byt,
+	}
+
+	res, _ := json.Marshal(expectedResult)
+
+	var resp volumeUUID
+	err := decodeResponse(bytes.NewReader(res), &resp)
+	if err == nil {
+		t.Log("No error occured")
+		t.Fail()
+	}
+
+	if errorMessage != err.Error() {
+		t.Logf("Expected: %s got %s\n", errorMessage, err.Error())
+		t.Fail()
+	}
+}
+
+func TestSuccesfullDecodeResponseWithErrorCode(t *testing.T) {
+	errorMessage := "ERROR_CODE_INVALID_REQUEST"
+	var byt json.RawMessage
+	byt, _ = json.Marshal(&rpcError{
+		Code: -32600,
+	})
+
+	expectedResult := &response{
+		ID:      int64(rand.Int63()),
+		Version: "2.0",
+		Error:   &byt,
+	}
+
+	res, _ := json.Marshal(expectedResult)
+
+	var resp volumeUUID
+	err := decodeResponse(bytes.NewReader(res), &resp)
+	if err == nil {
+		t.Log("No error occured")
+		t.Fail()
+	}
+
+	if errorMessage != err.Error() {
+		t.Logf("Expected: %s got %s\n", errorMessage, err.Error())
+		t.Fail()
+	}
+}
+
+func TestBadDecodeResponse(t *testing.T) {
+	expectedResult := &response{
+		ID:      int64(rand.Int63()),
+		Version: "2.0",
+	}
+
+	res, _ := json.Marshal(expectedResult)
+
+	var resp volumeUUID
+	err := decodeResponse(bytes.NewReader(res), &resp)
+	if err == nil {
+		t.Log("No error occured")
+		t.Fail()
+	}
+
+	if emptyResponse != err.Error() {
+		t.Logf("Expected: %s got %s\n", emptyResponse, err.Error())
+		t.Fail()
+	}
+}
+
+type decodeErrorCodeTest struct {
+	code     int
+	expected string
+}
+
+func TestDecodeErrorCode(t *testing.T) {
+	tests := []*decodeErrorCodeTest{
+		&decodeErrorCodeTest{code: -32600, expected: "ERROR_CODE_INVALID_REQUEST"},
+		&decodeErrorCodeTest{code: -32603, expected: "ERROR_CODE_JSON_ENCODING_FAILED"},
+		&decodeErrorCodeTest{code: -32601, expected: "ERROR_CODE_METHOD_NOT_FOUND"},
+		&decodeErrorCodeTest{code: -32700, expected: "ERROR_CODE_PARSE_ERROR"},
+	}
+
+	_ = tests
+	for _, decodeTest := range tests {
+		err := &rpcError{
+			Code: decodeTest.code,
+		}
+
+		if decodeTest.expected != err.decodeErrorCode() {
+			t.Logf("Expected: %s got %s\n", decodeTest.expected, err.decodeErrorCode())
+			t.Fail()
+		}
+	}
+}

--- a/rpc_client_test.go
+++ b/rpc_client_test.go
@@ -58,3 +58,5 @@ func TestSuccesfullDecodeResponse(t *testing.T) {}
 
 //TODO
 func TestSuccesfullDecodeResponseWithError(t *testing.T) {}
+
+//TODO test -> decodeErrorCode

--- a/rpc_client_test.go
+++ b/rpc_client_test.go
@@ -1,0 +1,60 @@
+package quobyte
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestSuccesfullEncodeRequest(t *testing.T) {
+	req := &CreateVolumeRequest{
+		RootUserID:  "root",
+		RootGroupID: "root",
+		Name:        "test",
+	}
+
+	//Generate Params here
+	var param map[string]interface{}
+	byt, _ := json.Marshal(req)
+	_ = json.Unmarshal(byt, &param)
+
+	expectedRPCRequest := &request{
+		ID:      0,
+		Method:  "createVolume",
+		Version: "2.0",
+		Params:  param,
+	}
+
+	res, err := encodeRequest("createVolume", req)
+	if err != nil {
+		t.Log(err)
+		t.FailNow()
+	}
+
+	var reqResult request
+	if err := json.Unmarshal(res, &reqResult); err != nil {
+		t.Log(err)
+		t.FailNow()
+	}
+
+	if expectedRPCRequest.Version != reqResult.Version {
+		t.Logf("Expected Version: %s got %s\n", expectedRPCRequest.Version, reqResult.Version)
+		t.Fail()
+	}
+
+	if expectedRPCRequest.Method != reqResult.Method {
+		t.Logf("Expected Method: %s got %s\n", expectedRPCRequest.Method, reqResult.Method)
+		t.Fail()
+	}
+
+	if !reflect.DeepEqual(expectedRPCRequest.Params, reqResult.Params) {
+		t.Logf("Expected Params: %v got %v\n", expectedRPCRequest.Params, reqResult.Params)
+		t.Fail()
+	}
+}
+
+//TODO
+func TestSuccesfullDecodeResponse(t *testing.T) {}
+
+//TODO
+func TestSuccesfullDecodeResponseWithError(t *testing.T) {}

--- a/types.go
+++ b/types.go
@@ -11,18 +11,24 @@ type CreateVolumeRequest struct {
 	TenantID          string  `json:"tenant_id,omitempty"`
 }
 
-type createVolumeResponse struct {
-	VolumeUUID string `json:"volume_uuid"`
-}
-
-type deleteVolumeRequest struct {
-	VolumeUUID string `json:"volume_uuid"`
-}
-
 type resolveVolumeNameRequest struct {
-	VolumeName string `json:"volume_name,omitempty"`
+	VolumeName   string `json:"volume_name,omitempty"`
+	TenantDomain string `json:"tenant_domain,omitempty"`
 }
 
-type resolveVolumeNameResponse struct {
+type volumeUUID struct {
 	VolumeUUID string `json:"volume_uuid,omitempty"`
+}
+
+type getClientListRequest struct {
+	TenantDomain string `json:"tenant_domain,omitempty"`
+}
+
+type GetClientListResponse struct {
+	Clients []Client `json:"client,omitempty"`
+}
+
+type Client struct {
+	MountedUserName   string `json:"mount_user_name,omitempty"`
+	MountedVolumeUUID string `json:"mounted_volume_uuid,omitempty"`
 }

--- a/types.go
+++ b/types.go
@@ -2,13 +2,13 @@ package quobyte
 
 // CreateVolumeRequest represents a CreateVolumeRequest
 type CreateVolumeRequest struct {
-	Name              string  `json:"name"`
-	RootUserID        string  `json:"root_user_id"`
-	RootGroupID       string  `json:"root_group_id"`
-	ReplicaDeviceIDS  []int64 `json:"replica_device_ids"`
-	ConfigurationName string  `json:"configuration_name"`
-	AccessMode        int32   `json:"access_mode"`
-	TenantID          string  `json:"tenant_id"`
+	Name              string  `json:"name,omitempty"`
+	RootUserID        string  `json:"root_user_id,omitempty"`
+	RootGroupID       string  `json:"root_group_id,omitempty"`
+	ReplicaDeviceIDS  []int64 `json:"replica_device_ids,omitempty"`
+	ConfigurationName string  `json:"configuration_name,omitempty"`
+	AccessMode        int32   `json:"access_mode,omitempty"`
+	TenantID          string  `json:"tenant_id,omitempty"`
 }
 
 type createVolumeResponse struct {

--- a/types.go
+++ b/types.go
@@ -1,9 +1,14 @@
 package quobyte
 
-type createVolumeRequest struct {
-	Name        string `json:"name"`
-	RootUserID  string `json:"root_user_id"`
-	RootGroupID string `json:"root_group_id"`
+// CreateVolumeRequest represents a CreateVolumeRequest
+type CreateVolumeRequest struct {
+	Name              string  `json:"name"`
+	RootUserID        string  `json:"root_user_id"`
+	RootGroupID       string  `json:"root_group_id"`
+	ReplicaDeviceIDS  []int64 `json:"replica_device_ids"`
+	ConfigurationName string  `json:"configuration_name"`
+	AccessMode        int32   `json:"access_mode"`
+	TenantID          string  `json:"tenant_id"`
 }
 
 type createVolumeResponse struct {
@@ -12,9 +17,6 @@ type createVolumeResponse struct {
 
 type deleteVolumeRequest struct {
 	VolumeUUID string `json:"volume_uuid"`
-}
-
-type deleteVolumeResponse struct {
 }
 
 type resolveVolumeNameRequest struct {


### PR DESCRIPTION
I changed the `CreateVolume` method to support all possible configurations and expects an `CreateVolumeRequest `. I will update the other methods too and possibly add one or to other API calls that could be useful.

The creation of a Volume has changed to this. The user can define any option(s) he wants if an option is not it will be ignored:

```go
package main

import (
  "log"
  quobyte_api "github.com/quobyte/api"
)

func main() {
    client := quobyte_api.NewQuobyteClient("http://apiserver:7860", "user", "password")
    req := &quobyte_api.CreateVolumeRequest{
        Name:              "MyVolume",
        RootUserID:        "root",
        RootGroupID:       "root",
        ConfigurationName: "base",
    }

    volume_uuid, err := client.CreateVolume(req)
    if err != nil {
        log.Fatalf("Error:", err)
    }

    log.Printf("%s", volume_uuid)
}
```

This probably breaks the build of the docker volume + every other tool using the go API. 

Any thoughts on this?