### PR TITLE
Update ID field in Response

### DIFF
--- a/rpc_client.go
+++ b/rpc_client.go
@@ -14,21 +14,21 @@ const (
 )
 
 type request struct {
-	ID      int64       `json:"id"`
+	ID      int64       `json:"id,string"`
 	Version string      `json:"jsonrpc"`
 	Method  string      `json:"method"`
 	Params  interface{} `json:"params"`
 }
 
 type response struct {
-	ID      int64            `json:"id"`
+	ID      int64            `json:"id,string"`
 	Version string           `json:"jsonrpc"`
 	Result  *json.RawMessage `json:"result"`
 	Error   *json.RawMessage `json:"error"`
 }
 
 type rpcError struct {
-	Code    int    `json:"code"`
+	Code    int64  `json:"code,string"`
 	Message string `json:"message"`
 }
 

--- a/rpc_client_test.go
+++ b/rpc_client_test.go
@@ -152,7 +152,7 @@ func TestBadDecodeResponse(t *testing.T) {
 }
 
 type decodeErrorCodeTest struct {
-	code     int
+	code     int64
 	expected string
 }
 

--- a/types.go
+++ b/types.go
@@ -2,13 +2,13 @@ package quobyte
 
 // CreateVolumeRequest represents a CreateVolumeRequest
 type CreateVolumeRequest struct {
-	Name              string  `json:"name,omitempty"`
-	RootUserID        string  `json:"root_user_id,omitempty"`
-	RootGroupID       string  `json:"root_group_id,omitempty"`
-	ReplicaDeviceIDS  []int64 `json:"replica_device_ids,omitempty"`
-	ConfigurationName string  `json:"configuration_name,omitempty"`
-	AccessMode        int32   `json:"access_mode,omitempty"`
-	TenantID          string  `json:"tenant_id,omitempty"`
+	Name              string   `json:"name,omitempty"`
+	RootUserID        string   `json:"root_user_id,omitempty"`
+	RootGroupID       string   `json:"root_group_id,omitempty"`
+	ReplicaDeviceIDS  []uint64 `json:"replica_device_ids,string,omitempty"`
+	ConfigurationName string   `json:"configuration_name,omitempty"`
+	AccessMode        uint32   `json:"access_mode,string,omitempty"`
+	TenantID          string   `json:"tenant_id,omitempty"`
 }
 
 type resolveVolumeNameRequest struct {


### PR DESCRIPTION
I missed a small case in my testing scenario:

```json
{
  "id": "text", 
  "jsonrpc": "2.0", 
  "result": {
    "...": "..."
  }
}
```

the `id` field is a String and golang will report an error if it tries to unmarshal it into an `int`, so we need to add the `string` to the json tag:

```

The "string" option signals that a field is stored as JSON inside a JSON-encoded string. 
It applies only to fields of string, floating point, integer, or boolean types. 
This extra level of encoding is sometimes used when communicating with JavaScript programs:

Int64String int64 `json:",string"`
```

Everything worked well (creation etc.) but unmarshalling the Response resulted in the following error:

```
Error response from daemon: create ...: VolumeDriver.Create: json: cannot unmarshal string into Go value of type int64
```

I didn't catch this test because in https://github.com/gorilla/rpc/blob/master/v2/json2/client.go#L35 they completely ignore the `ID` of the Response.

TLDR: Sorry (my fault) missed this test case.