### PR TITLE
Change ID type from int64 to string

### DIFF
--- a/rpc_client.go
+++ b/rpc_client.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"math/rand"
 	"net/http"
+	"strconv"
 )
 
 const (
@@ -14,21 +15,21 @@ const (
 )
 
 type request struct {
-	ID      int64       `json:"id,string"`
+	ID      string      `json:"id"`
 	Version string      `json:"jsonrpc"`
 	Method  string      `json:"method"`
 	Params  interface{} `json:"params"`
 }
 
 type response struct {
-	ID      int64            `json:"id,string"`
+	ID      string           `json:"id"`
 	Version string           `json:"jsonrpc"`
 	Result  *json.RawMessage `json:"result"`
 	Error   *json.RawMessage `json:"error"`
 }
 
 type rpcError struct {
-	Code    int64  `json:"code,string"`
+	Code    int64  `json:"code"`
 	Message string `json:"message"`
 }
 
@@ -49,7 +50,8 @@ func (err *rpcError) decodeErrorCode() string {
 
 func encodeRequest(method string, params interface{}) ([]byte, error) {
 	return json.Marshal(&request{
-		ID:      int64(rand.Int63()),
+		// Generate random ID and convert it to a string
+		ID:      strconv.FormatInt(rand.Int63(), 10),
 		Version: "2.0",
 		Method:  method,
 		Params:  params,

--- a/rpc_client_test.go
+++ b/rpc_client_test.go
@@ -3,7 +3,6 @@ package quobyte
 import (
 	"bytes"
 	"encoding/json"
-	"math/rand"
 	"reflect"
 	"testing"
 )
@@ -21,7 +20,7 @@ func TestSuccesfullEncodeRequest(t *testing.T) {
 	_ = json.Unmarshal(byt, &param)
 
 	expectedRPCRequest := &request{
-		ID:      0,
+		ID:      "0",
 		Method:  "createVolume",
 		Version: "2.0",
 		Params:  param,
@@ -53,7 +52,7 @@ func TestSuccesfullDecodeResponse(t *testing.T) {
 	byt, _ = json.Marshal(map[string]interface{}{"volume_uuid": "1234"})
 
 	expectedResult := &response{
-		ID:      int64(rand.Int63()),
+		ID:      "0",
 		Version: "2.0",
 		Result:  &byt,
 	}
@@ -82,7 +81,7 @@ func TestSuccesfullDecodeResponseWithErrorMessage(t *testing.T) {
 	})
 
 	expectedResult := &response{
-		ID:      int64(rand.Int63()),
+		ID:      "0",
 		Version: "2.0",
 		Error:   &byt,
 	}
@@ -110,7 +109,7 @@ func TestSuccesfullDecodeResponseWithErrorCode(t *testing.T) {
 	})
 
 	expectedResult := &response{
-		ID:      int64(rand.Int63()),
+		ID:      "0",
 		Version: "2.0",
 		Error:   &byt,
 	}
@@ -132,7 +131,7 @@ func TestSuccesfullDecodeResponseWithErrorCode(t *testing.T) {
 
 func TestBadDecodeResponse(t *testing.T) {
 	expectedResult := &response{
-		ID:      int64(rand.Int63()),
+		ID:      "0",
 		Version: "2.0",
 	}
 


### PR DESCRIPTION
After having some trouble with decoding of the Error Code field I changed the ID type from `int64` to `string` and removed the `string` json tag from the Error Code:

```
$ go run main.go
2016/09/12 16:01:01 Error:%!(EXTRA *json.UnmarshalTypeError=json: cannot unmarshal string into Go value of type int64)
exit status 1
```

and with the changed type to `string`:

```
$ go run main.go
2016/09/12 16:01:36 Success!
```

The change to the type `string` also offers more flexibility (this allows to use characters in the ID).

Basically the main problem is the Unmarshal Operation of golang:

1.) You have the type 
```
ID      int64       `json:"id,string"`
```

Works fine for:

````
{
    "id": "1337"
}
```

but not for 


````
{
    "id":  1337
}
```

A little side effect -> the tests are running even faster :)