### PR TITLE
Add GetDeviceNetworkEndpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,7 @@ func main() {
     log.Printf("%s", volume_uuid)
 }
 ```
+
+## Docs
+
+https://godoc.org/github.com/quobyte/api

--- a/quobyte.go
+++ b/quobyte.go
@@ -1,7 +1,9 @@
 // Package quobyte represents a golang API for the Quobyte Storage System
 package quobyte
 
-import "net/http"
+import (
+	"net/http"
+)
 
 type QuobyteClient struct {
 	client   *http.Client
@@ -37,11 +39,9 @@ func (client *QuobyteClient) ResolveVolumeNameToUUID(volumeName, tenant string) 
 		TenantDomain: tenant,
 	}
 	var response volumeUUID
-	if err := client.sendRequest("resolveVolumeName", request, &response); err != nil {
-		return "", err
-	}
+	err := client.sendRequest("resolveVolumeName", request, &response)
 
-	return response.VolumeUUID, nil
+	return response.VolumeUUID, err
 }
 
 // DeleteVolume deletes a Quobyte volume
@@ -71,9 +71,20 @@ func (client *QuobyteClient) GetClientList(tenant string) (GetClientListResponse
 	}
 
 	var response GetClientListResponse
-	if err := client.sendRequest("getClientListRequest", request, &response); err != nil {
-		return response, err
+	err := client.sendRequest("getClientListRequest", request, &response)
+
+	return response, err
+}
+
+// GetDeviceNetworkEndpoints returns a List of all requested DeviceNetworkEndpoints can be a single element or a list of DeviceNetworkEndpoints
+func (client *QuobyteClient) GetDeviceNetworkEndpoints(deviceID uint64) (GetDeviceNetworkEndpointsResponse, error) {
+	request := &GetDeviceNetworkEndpointsRequest{}
+	if deviceID > 0 {
+		request.DeviceID = deviceID
 	}
 
-	return response, nil
+	var response GetDeviceNetworkEndpointsResponse
+	err := client.sendRequest("getDeviceNetworkEndpoints", request, &response)
+
+	return response, err
 }

--- a/quobyte.go
+++ b/quobyte.go
@@ -88,3 +88,14 @@ func (client *QuobyteClient) GetDeviceNetworkEndpoints(deviceID uint64) (GetDevi
 
 	return response, err
 }
+
+// GetDeviceList returns a List of all requested Devices can be a single element or a list of Devices
+func (client *QuobyteClient) GetDeviceList(deviceIDs []uint64, deviceTypes []string) (GetDeviceListResponse, error) {
+	var response GetDeviceListResponse
+	err := client.sendRequest("getDeviceList", &GetDeviceListRequest{
+		DeviceID:   deviceIDs,
+		DeviceType: deviceTypes,
+	}, &response)
+
+	return response, err
+}

--- a/types.go
+++ b/types.go
@@ -46,3 +46,62 @@ type DeviceNetworkEndpoint struct {
 type GetDeviceNetworkEndpointsResponse struct {
 	Endpoints []DeviceNetworkEndpoint `json:"endpoints,omitempty"`
 }
+
+type GetDeviceListRequest struct {
+	DeviceID   []uint64 `json:"device_id,omitempty"`
+	DeviceType []string `json:"device_type,omitempty"`
+}
+
+type GetDeviceListResponse struct {
+	DeviceList DeviceList `json:"device_list,omitempty"`
+}
+
+type DeviceList struct {
+	Devices []Device `json:"devices,omitempty"`
+}
+
+type Device struct {
+	DeviceStatus            string              `json:"device_status,omitempty"`
+	DeviceID                uint64              `json:"device_id,omitempty"`
+	DeviceLabel             string              `json:"device_label,omitempty"`
+	Content                 []DeviceContent     `json:"content,omitempty"`
+	HostName                string              `json:"host_name,omitempty"`
+	TotalDiskSpaceBytes     uint64              `json:"total_disk_space_bytes,omitempty"`
+	UsedDiskSpaceBytes      uint64              `json:"used_disk_space_bytes,omitempty"`
+	DeviceTags              []string            `json:"device_tags,omitempty"`
+	FailureDomainInfos      []FailureDomainInfo `json:"failure_domain_infos,omitempty"`
+	IsEmpty                 bool                `json:"is_empty,omitempty"`
+	Draining                bool                `json:"draining,omitempty"`
+	DeviceSerialNumber      string              `json:"device_serial_number,omitempty"`
+	DeviceModel             string              `json:"device_model,omitempty"`
+	DetectedDiskType        string              `json:"detected_disk_type,omitempty"`
+	CurrentMountPathstring  string              `json:"current_mount_pathstring,omitempty"`
+	FileCount               int64               `json:"file_count,omitempty"`
+	VolumeDatabaseCount     int64               `json:"volume_database_count,omitempty"`
+	RegistryDatabaseCount   int64               `json:"registry_database_countcontent,omitempty"`
+	IOErrorCount            int64               `json:"io_error_count,omitempty"`
+	CRCErrorCount           int64               `json:"crc_error_count,omitempty"`
+	LastSuccessfulCleanupMS int64               `json:"last_successful_cleanup_ms,omitempty"`
+	CurrentUtilization      float64             `json:"current_utilization,omitempty"`
+	ReallocatedSectorCt     int64               `json:"reallocated_sector_ct,omitempty"`
+	ReportedUncorrect       int64               `json:"reported_uncorrect,omitempty"`
+	CommandTimeout          int64               `json:"command_timeout,omitempty"`
+	CurrentPendingSector    int64               `json:"current_pending_sector,omitempty"`
+	OfflineUncorrectable    int64               `json:"offline_uncorrectable,omitempty"`
+	IsPrimary               bool                `json:"is_primary,omitempty"`
+}
+
+type DeviceContent struct {
+	ContentType         string `json:"content_type,omitempty"`
+	ServiceUUID         string `json:"service_uuid,omitempty"`
+	LastSeenTimestampMS uint64 `json:"last_seen_timestamp_ms,omitempty"`
+	Available           bool   `json:"available,omitempty"`
+	LastSeenServiceUUID string `json:"last_seen_service_uuid,omitempty"`
+	LastSeenServiceName string `json:"last_seen_service_name,omitempty"`
+	LastSeenMountPath   string `json:"last_seen_mount_path,omitempty"`
+}
+
+type FailureDomainInfo struct {
+	Name       string `json:"name,omitempty"`
+	DomainType string `json:"domain_type,omitempty"`
+}

--- a/types.go
+++ b/types.go
@@ -32,3 +32,17 @@ type Client struct {
 	MountedUserName   string `json:"mount_user_name,omitempty"`
 	MountedVolumeUUID string `json:"mounted_volume_uuid,omitempty"`
 }
+
+type GetDeviceNetworkEndpointsRequest struct {
+	DeviceID uint64 `json:"device_id,omitempty"`
+}
+
+type DeviceNetworkEndpoint struct {
+	DeviceType string `json:"device_type,omitempty"`
+	Hostname   string `json:"hostname,omitempty"`
+	Port       int    `json:"devicporte_id,omitempty"`
+}
+
+type GetDeviceNetworkEndpointsResponse struct {
+	Endpoints []DeviceNetworkEndpoint `json:"endpoints,omitempty"`
+}


### PR DESCRIPTION
This PR adds the `GetDeviceNetworkEndpoints` method from the Management API to the go-client.