### PR TITLE
Allow to fetch tenants and create tenants

### DIFF
--- a/quobyte.go
+++ b/quobyte.go
@@ -80,6 +80,7 @@ func (client *QuobyteClient) GetClientList(tenant string) (GetClientListResponse
 	return response, nil
 }
 
+// SetVolumeQuota sets a Quota to the specified Volume
 func (client *QuobyteClient) SetVolumeQuota(volumeUUID string, quotaSize uint64) error {
 	request := &setQuotaRequest{
 		Quotas: []*quota{
@@ -101,4 +102,50 @@ func (client *QuobyteClient) SetVolumeQuota(volumeUUID string, quotaSize uint64)
 	}
 
 	return client.sendRequest("setQuota", request, nil)
+}
+
+// GetTenant returns the Tenant configuration for all specified tenants
+func (client *QuobyteClient) GetTenant(tenantIDs []string) (GetTenantResponse, error) {
+	request := &getTenantRequest{TenantIDs: tenantIDs}
+
+	var response GetTenantResponse
+	err := client.sendRequest("getTenant", request, &response)
+	if err != nil {
+		return response, err
+	}
+
+	return response, nil
+}
+
+// GetTenantMap returns a map that contains all tenant names and there ID's
+func (client *QuobyteClient) GetTenantMap() (map[string]string, error) {
+	result := map[string]string{}
+	response, err := client.GetTenant([]string{})
+
+	if err != nil {
+		return result, err
+	}
+
+	for _, tenant := range response.Tenants {
+		result[tenant.Name] = tenant.TenantID
+	}
+
+	return result, nil
+}
+
+// SetTenant creates a Tenant with the specified name
+func (client *QuobyteClient) SetTenant(tenantName string) (string, error) {
+	request := &setTenantRequest{
+		&TenantDomainConfiguration{
+			Name: tenantName,
+		},
+	}
+
+	var response setTenantResponse
+	err := client.sendRequest("setTenant", request, &response)
+	if err != nil {
+		return "", err
+	}
+
+	return response.TenantID, nil
 }

--- a/types.go
+++ b/types.go
@@ -54,3 +54,32 @@ type quota struct {
 type setQuotaRequest struct {
 	Quotas []*quota `json:"quotas,omitempty"`
 }
+
+type getTenantRequest struct {
+	TenantIDs []string `json:"tenant_id,omitempty"`
+}
+
+type GetTenantResponse struct {
+	Tenants []*TenantDomainConfiguration `json:"tenant,omitempty"`
+}
+
+type TenantDomainConfiguration struct {
+	TenantID          string                                   `json:"tenant_id,omitempty"`
+	Name              string                                   `json:"name,omitempty"`
+	RestrictToNetwork []string                                 `json:"restrict_to_network,omitempty"`
+	VolumeAccess      []*TenantDomainConfigurationVolumeAccess `json:"volume_access,omitempty"`
+}
+
+type TenantDomainConfigurationVolumeAccess struct {
+	VolumeUUID        string `json:"volume_uuid,omitempty"`
+	RestrictToNetwork string `json:"restrict_to_network,omitempty"`
+	ReadOnly          bool   `json:"read_only,omitempty"`
+}
+
+type setTenantRequest struct {
+	Tenants *TenantDomainConfiguration `json:"tenant,omitempty"`
+}
+
+type setTenantResponse struct {
+	TenantID string `json:"tenant_id,omitempty"`
+}


### PR DESCRIPTION
This allows to fetch a list with all Tenant Names and their ID's as a map. Also you can fetch information about specific (or all) tenants by their ID and you can create tenants by their name (currently without restrictions).