### PR TITLE
Tenant name resolution

### DIFF
--- a/quobyte.go
+++ b/quobyte.go
@@ -2,6 +2,7 @@
 package quobyte
 
 import (
+	"log"
 	"net/http"
 	"regexp"
 )
@@ -46,7 +47,8 @@ func (client QuobyteClient) CreateVolume(request *CreateVolumeRequest) (string, 
 	var response volumeUUID
 
 	if request.TenantID != "" && !IsValidUUID(request.TenantID) {
-		tenantUUID, err := client.ResolveTeantanNameTOUUID(request.TenantID)
+		log.Printf("Tenant name resolution: Resolving  %s to UUID\n", request.TenantID)
+		tenantUUID, err := client.ResolveTenantNameToUUID(request.TenantID)
 		if err != nil {
 			return "", err
 		}
@@ -186,14 +188,14 @@ func IsValidUUID(uuid string) bool {
 	return r.MatchString(uuid)
 }
 
-// ResolveTeantanNameTOUUID Returns UUID for given name, error if not found.
-func (client *QuobyteClient) ResolveTeantanNameTOUUID(name string) (string, error) {
+// ResolveTenantNameToUUID Returns UUID for given name, error if not found.
+func (client *QuobyteClient) ResolveTenantNameToUUID(name string) (string, error) {
 	request := &resolveTenantNameRequest{
 		TenantName: name,
 	}
 
 	var response resolveTenantNameResponse
-	err := client.sendRequest("resolveTenantNameRequest", request, &response)
+	err := client.sendRequest("resolveTenantName", request, &response)
 	if err != nil {
 		return "", err
 	}

--- a/quobyte.go
+++ b/quobyte.go
@@ -3,6 +3,7 @@ package quobyte
 
 import (
 	"net/http"
+	"regexp"
 )
 
 // retry policy codes
@@ -43,6 +44,16 @@ func NewQuobyteClient(url string, username string, password string) *QuobyteClie
 // CreateVolume creates a new Quobyte volume. Its root directory will be owned by given user and group
 func (client QuobyteClient) CreateVolume(request *CreateVolumeRequest) (string, error) {
 	var response volumeUUID
+
+	if request.TenantID != "" && !IsValidUUID(request.TenantID) {
+		tenantUUID, err := client.ResolveTeantanNameTOUUID(request.TenantID)
+		if err != nil {
+			return "", err
+		}
+
+		request.TenantID = tenantUUID
+	}
+
 	if err := client.sendRequest("createVolume", request, &response); err != nil {
 		return "", err
 	}
@@ -166,5 +177,25 @@ func (client *QuobyteClient) SetTenant(tenantName string) (string, error) {
 		return "", err
 	}
 
+	return response.TenantID, nil
+}
+
+// IsValidUUID Validates given uuid
+func IsValidUUID(uuid string) bool {
+	r := regexp.MustCompile("^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-4[a-fA-F0-9]{3}-[8|9|aA|bB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$")
+	return r.MatchString(uuid)
+}
+
+// ResolveTeantanNameTOUUID Returns UUID for given name, error if not found.
+func (client *QuobyteClient) ResolveTeantanNameTOUUID(name string) (string, error) {
+	request := &resolveTenantNameRequest{
+		TenantName: name,
+	}
+
+	var response resolveTenantNameResponse
+	err := client.sendRequest("resolveTenantNameRequest", request, &response)
+	if err != nil {
+		return "", err
+	}
 	return response.TenantID, nil
 }

--- a/types.go
+++ b/types.go
@@ -22,6 +22,14 @@ type resolveVolumeNameRequest struct {
         retryPolicy
 }
 
+type resolveTenantNameRequest struct {
+	TenantName string `json:"tenant_name,omitempty"`
+}
+
+type resolveTenantNameResponse struct {
+	TenantID string `json:"tenant_id,omitempty"`
+}
+
 type volumeUUID struct {
 	VolumeUUID string `json:"volume_uuid,omitempty"`
 }


### PR DESCRIPTION
Supports both Tenant UUID and Name.
Uses UUID (identifies UUID based on the UUID pattern) when given, otherwise tries to resolve the UUID for given name.