### PR TITLE
Add labels volume create request

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ func main() {
         RootUserID:        "root",
         RootGroupID:       "root",
         ConfigurationName: "BASE",
+        Labels: []quobyte_api.Label{
+            {Name: "label1", Value: "value1"},
+            {Name: "label2", Value: "value2"},
+        },
     }
 
     volumeUUID, err := client.CreateVolume(req)

--- a/types.go
+++ b/types.go
@@ -1,25 +1,25 @@
 package quobyte
 
 type retryPolicy struct {
-        RetryPolicy string `json:"retry,omitempty"`
+	RetryPolicy string `json:"retry,omitempty"`
 }
 
 // CreateVolumeRequest represents a CreateVolumeRequest
 type CreateVolumeRequest struct {
-        Name              string   `json:"name,omitempty"`
-        RootUserID        string   `json:"root_user_id,omitempty"`
-        RootGroupID       string   `json:"root_group_id,omitempty"`
-        ReplicaDeviceIDS  []uint64 `json:"replica_device_ids,string,omitempty"`
-        ConfigurationName string   `json:"configuration_name,omitempty"`
-        AccessMode        uint32   `json:"access_mode,uint32,omitempty"`
-        TenantID          string   `json:"tenant_id,omitempty"`
-        retryPolicy
+	Name              string   `json:"name,omitempty"`
+	RootUserID        string   `json:"root_user_id,omitempty"`
+	RootGroupID       string   `json:"root_group_id,omitempty"`
+	ReplicaDeviceIDS  []uint64 `json:"replica_device_ids,string,omitempty"`
+	ConfigurationName string   `json:"configuration_name,omitempty"`
+	AccessMode        uint32   `json:"access_mode,uint32,omitempty"`
+	TenantID          string   `json:"tenant_id,omitempty"`
+	retryPolicy
 }
 
 type resolveVolumeNameRequest struct {
-        VolumeName   string `json:"volume_name,omitempty"`
-        TenantDomain string `json:"tenant_domain,omitempty"`
-        retryPolicy
+	VolumeName   string `json:"volume_name,omitempty"`
+	TenantDomain string `json:"tenant_domain,omitempty"`
+	retryPolicy
 }
 
 type resolveTenantNameRequest struct {
@@ -35,8 +35,8 @@ type volumeUUID struct {
 }
 
 type getClientListRequest struct {
-        TenantDomain string `json:"tenant_domain,omitempty"`
-        retryPolicy
+	TenantDomain string `json:"tenant_domain,omitempty"`
+	retryPolicy
 }
 
 type GetClientListResponse struct {
@@ -67,13 +67,13 @@ type quota struct {
 }
 
 type setQuotaRequest struct {
-        Quotas []*quota `json:"quotas,omitempty"`
-        retryPolicy
+	Quotas []*quota `json:"quotas,omitempty"`
+	retryPolicy
 }
 
 type getTenantRequest struct {
-        TenantIDs []string `json:"tenant_id,omitempty"`
-        retryPolicy
+	TenantIDs []string `json:"tenant_id,omitempty"`
+	retryPolicy
 }
 
 type GetTenantResponse struct {
@@ -94,8 +94,8 @@ type TenantDomainConfigurationVolumeAccess struct {
 }
 
 type setTenantRequest struct {
-        Tenants *TenantDomainConfiguration `json:"tenant,omitempty"`
-        retryPolicy
+	Tenants *TenantDomainConfiguration `json:"tenant,omitempty"`
+	retryPolicy
 }
 
 type setTenantResponse struct {

--- a/types.go
+++ b/types.go
@@ -11,9 +11,15 @@ type CreateVolumeRequest struct {
 	RootGroupID       string   `json:"root_group_id,omitempty"`
 	ReplicaDeviceIDS  []uint64 `json:"replica_device_ids,string,omitempty"`
 	ConfigurationName string   `json:"configuration_name,omitempty"`
+	Labels            []Label  `json:"label,omitempty"`
 	AccessMode        uint32   `json:"access_mode,uint32,omitempty"`
 	TenantID          string   `json:"tenant_id,omitempty"`
 	retryPolicy
+}
+
+type Label struct {
+	Name  string `json:"name,string,omitempty"`
+	Value string `json:"value,string,omitempty"`
 }
 
 type resolveVolumeNameRequest struct {


### PR DESCRIPTION
With Quobyte 3.0, the user can add volume labels to newly created volumes.
This patch adds the label fields to the golang api for being used in Quobyte CSI driver.