### PR TITLE
Add HTTP transport option to client

### DIFF
--- a/quobyte.go
+++ b/quobyte.go
@@ -32,6 +32,10 @@ func (client *QuobyteClient) GetAPIRetryPolicy() string {
 	return client.apiRetryPolicy
 }
 
+func (client *QuobyteClient) SetTransport(t http.RoundTripper) {
+	client.client.Transport = t
+}
+
 // NewQuobyteClient creates a new Quobyte API client
 func NewQuobyteClient(url string, username string, password string) *QuobyteClient {
 	return &QuobyteClient{


### PR DESCRIPTION
This adds a configurable RoundTripper to the client library,
which will be invoked to create HTTP/HTTPS connections.

Allowing a custom Transport captures a wide variety of use cases and
behaviors by delegating the responsibility to the caller.

For example, users can set dial timeouts, share connections, or
tunnel/proxy connections using custom logic.

**Note to reviewers**

This change is needed for kubernetes maintenance of the legacy storage drivers.