### PR TITLE
Revert "Do not log HTTP response body"

### DIFF
--- a/rpc_client.go
+++ b/rpc_client.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
+	"io/ioutil"
 	"log"
 	"math/rand"
 	"net/http"
@@ -118,7 +118,12 @@ func (client QuobyteClient) sendRequest(method string, request interface{}, resp
 		if resp.StatusCode == 401 {
 			return errors.New("Unable to authenticate with Quobyte API service")
 		}
-		return fmt.Errorf("JsonRPC failed with error code %d", resp.StatusCode)
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return (err)
+		}
+		log.Printf("Warning: Dumping full reply body:\n%s\n", string(body))
+		return errors.New("JsonRPC failed, see plugin logfile for details")
 	}
 	return decodeResponse(resp.Body, &response)
 }


### PR DESCRIPTION
Error message alone is not sufficient to determine the cause of failure. The body includes the reason for failure (missing required values, invalid values etc)  and should be communicated back to end user. So, reverting this fix.

Instead of logging the body, it can be appended to error and sent back to user.


