### PR TITLE
Return the complete error message from API to end user (k8s)

### DIFF
--- a/rpc_client.go
+++ b/rpc_client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
@@ -113,8 +114,6 @@ func (client QuobyteClient) sendRequest(method string, request interface{}, resp
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		log.Printf("Warning: HTTP status code for request is %s\n",
-			strconv.Itoa(resp.StatusCode))
 		if resp.StatusCode == 401 {
 			return errors.New("Unable to authenticate with Quobyte API service")
 		}
@@ -122,8 +121,8 @@ func (client QuobyteClient) sendRequest(method string, request interface{}, resp
 		if err != nil {
 			return (err)
 		}
-		log.Printf("Warning: Dumping full reply body:\n%s\n", string(body))
-		return errors.New("JsonRPC failed, see plugin logfile for details")
+		return fmt.Errorf("JsonRPC failed with error (error code: %d) %s",
+                  resp.StatusCode, string(body))
 	}
 	return decodeResponse(resp.Body, &response)
 }


### PR DESCRIPTION
Sends back complete error message with the response code back to the API user.
In K8S, the current API only displaying the "JsonRPC failed, check plugin logs" and relevant logs could not be found anywhere else. So, API needs to send back all the error information back to the user.