### PR TITLE
Handle 401 Unauthorized properly

### DIFF
--- a/quobyte/rpc_client.go
+++ b/quobyte/rpc_client.go
@@ -103,13 +103,13 @@ func (client QuobyteClient) sendRequest(method string, request interface{}, resp
 	if err != nil {
 		return err
 	}
-	req, err := http.NewRequest("POST", client.url.String(), bytes.NewBuffer(message))
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Content-Type", "application/json")
 	// If no cookies, serialize requests such that first successful request sets the cookies
 	for {
+		req, err := http.NewRequest("POST", client.url.String(), bytes.NewBuffer(message))
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Content-Type", "application/json")
 		mux.Lock()
 		hasCookies, err := client.hasCookies()
 		if err != nil {


### PR DESCRIPTION
This PR fixes the handling of `401 Unauthorized`.

Currently, we get the following error when the session is expired (`401 Unauthorized`).

```
Post "http://<QUOBYTE_API>": http: ContentLength=125 with Body length 0
```

`sendRequest` reuses the `http.Request` object created out of the loop, so [the request body is already closed](https://stackoverflow.com/questions/31337891/net-http-http-contentlength-222-with-body-length-0) when `sendRequest` handle `401` in the second loop.

The unit test I added and the current logic can reproduce the current problem.

```
$ go test -v . -run TestSendRequest
=== RUN   TestSendRequest
    rpc_client_test.go:202: Unexpected error (i=1): Post "http://127.0.0.1:56922": http: ContentLength=125 with Body length 0
--- FAIL: TestSendRequest (0.01s)
FAIL
FAIL    github.com/quobyte/api/quobyte  0.158s
FAIL
```
