### PR TITLE
Remove redundant return statement

### DIFF
--- a/quobyte/quobyte.go
+++ b/quobyte/quobyte.go
@@ -58,7 +58,6 @@ func NewQuobyteClient(urlStr string, username string, password string) *QuobyteC
 		password:       password,
 		apiRetryPolicy: RetryInteractive,
 	}
-	return nil
 }
 
 // GetVolumeUUID resolves the volumeUUID for the given volume and tenant name.


### PR DESCRIPTION
This PR removes the redundant return statement in `NewQuobyteClient()`.

This return statement is currently unreachable.

```
$ go vet github.com/quobyte/api/...
# github.com/quobyte/api/quobyte
quobyte/quobyte.go:61:2: unreachable code
```
